### PR TITLE
Bump cibuildwheel version to 2.11.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.1
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Ensures that we build also for CPython 3.11