### PR TITLE
Switch macOS build targets from 10.15 to 11 and 12

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11, macos-12 ]
 
     env:
       CIBW_SKIP: pp*


### PR DESCRIPTION
Avoids macOS versions deprecated by the Github Actions runner.

@DavidMStraub Sorry, if I had known about the deprecation, I'd have bumped both OS and cibuildwheel version simultaneously!