### PR TITLE
Build wheels also for linux/aarch64 and update README regarding CI system

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       CIBW_SKIP: pp*
       CIBW_ARCHS_MACOS: x86_64 arm64
+      CIBW_ARCHS_LINUX: x86_64 aarch64
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ crd.mMS2mOS(4.18, None,  0.26, 4.18, 5, 2)
 
 The wrapper was generated with [SWIG](http://www.swig.org/).
 
-Binary wheels are provided via [PyPI](https://pypi.python.org/pypi/rundec) for Linux and Mac OS (built on [Travis CI](https://travis-ci.org/)) and for Windows (built on [AppVeyor](https://www.appveyor.com/)).
+Binary wheels are provided via [PyPI](https://pypi.python.org/pypi/rundec) for Linux, macOS, and Windows (built with [GitHub Actions](https://github.com/features/actions)).
 
-The Windows wheels require Python 3.5+, on Linux and Mac OS Python 2.7+ is sufficient.
+The Windows wheels require Python 3.5+, on Linux and macOS Python 2.7+ is sufficient.


### PR DESCRIPTION
Hi @DavidMStraub,

I was wondering if you would consider merging this PR, which minimally affects the workflow; the README change is cosmetic.

My rationale is that people using VS code devcontainers (i.e., linux containers) on macOS would benefit from running their containers natively on aarch64, rather than emulating x86_64.

Best,
Danny