### PR TITLE
Install qemu-user-static to enable aarch64 emulation

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.2
 
+      - name: Install QEMU and emulation on the Ubuntu runner
+        if: runner.os == 'Linux'
+        run: sudo apt install qemu-user-static
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 


### PR DESCRIPTION
Hi @DavidMStraub,

this commit works in my fork.

It install a statically-linked qemu into the host container, which allows cibuildwheel (or rather its calls to docker) to run cross-platform containers. I have made the installation of qemu conditional on the GitHub Actions runner being the Linux runner.

Cheers,
Danny