### PR TITLE
Bump cibuildwheel version to 2.16.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.11.2
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Install QEMU and emulation on the Ubuntu runner
         if: runner.os == 'Linux'


### PR DESCRIPTION
Means we build for python 3.12