### PR TITLE
Bump cibuildwheel version to 2.21.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.3
 
       - name: Install QEMU and emulation on the Ubuntu runner
         if: runner.os == 'Linux'


### PR DESCRIPTION
This should make cibuildwheel build wheels for CPython 3.13.